### PR TITLE
update to industries functions layer

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -91,7 +91,7 @@ if mods["angelsindustries"] then
         end
 
         if settings.startup["angels-return-ingredients"].value then
-            add_minable_results()
+            angelsmods.functions.AI.add_minable_results()
             OV.execute()
         end
     end


### PR DESCRIPTION
This is in prep for the upcoming angels release, I have moved the industries functions out of global and into angelsmods.functions.AI for consistency, this may save effort if we decide to move the functions from industries to refining with the rest of the lib in future.